### PR TITLE
Adapt brouter for elevation tiles in Esri ASCII format. Tiles come from Asamm dataset converted by GDAL.

### DIFF
--- a/brouter-map-creator/src/main/java/btools/mapcreator/PosUnifier.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/PosUnifier.java
@@ -173,15 +173,16 @@ public class PosUnifier extends MapCreatorBase
   }
 
   public int lonIndexHgt(int ilon){
-    return indexHgt(doublelon(ilon));
+    return indexHgt(doublelon(ilon), 180.0);
   }
 
   public int latIndexHgt(int ilat){
-    return indexHgt(doublelat(ilat));
+    return indexHgt(doublelat(ilat), 90.0);
   }
 
-  public int indexHgt(double coord){
-    if (coord >= 180.0) coord = 179.99999; // north pole 90.0 ignored...
+  public int indexHgt(double coord, double bound){
+    if (coord >= bound) coord = bound - .000001;
+    if (coord < -bound) coord = -bound + .000001;
     // adjust for south and west hemispheres
     if(coord < 0.0 && coord% 1.0 != 0.0) coord -= 1.0;
     return (int) coord;

--- a/brouter-map-creator/src/main/java/btools/mapcreator/PosUnifier.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/PosUnifier.java
@@ -200,7 +200,12 @@ public class PosUnifier extends MapCreatorBase
     return hemilat + latS.substring(latS.length() - 2) + hemiLon + lonS.substring(lonS.length() -3);
   }
 
-  private SrtmRaster srtmForNode( int ilon, int ilat ) throws Exception
+  // integration tests
+  public void setSrtmdir(String dir){
+    this.srtmdir = dir;
+  }
+
+  public SrtmRaster srtmForNode( int ilon, int ilat ) throws Exception
   {
 
     int srtmLonIdx = lonIndexHgt(ilon);
@@ -259,7 +264,7 @@ public class PosUnifier extends MapCreatorBase
     return lastSrtmRaster;
   }
 
-  private void resetSrtm()
+  public void resetSrtm()
   {
     srtmmap = new HashMap<String, SrtmRaster>();
     lastSrtmLonIdx = -9999;

--- a/brouter-map-creator/src/main/java/btools/mapcreator/PosUnifier.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/PosUnifier.java
@@ -158,14 +158,53 @@ public class PosUnifier extends MapCreatorBase
     System.out.println( "*** WARNING: cannot unify position for: " + n.ilon + " " + n.ilat );
   }
 
+  /*
+    ilon, ilat are produced like this: see btools.mapcreator.NodeData
+    ilat = (int)( ( lat + 90. )*1000000. + 0.5);
+    ilon = (int)( ( lon + 180. )*1000000. + 0.5);
+  */
+
+  public double doublelon(int ilon){
+    return (ilon / 1000000.0) - 180.0;
+  }
+
+  public double doublelat(int ilat){
+    return (ilat / 1000000.0) - 90.0;
+  }
+
+  public int lonIndexHgt(int ilon){
+    return indexHgt(doublelon(ilon));
+  }
+
+  public int latIndexHgt(int ilat){
+    return indexHgt(doublelat(ilat));
+  }
+
+  public int indexHgt(double coord){
+    if (coord >= 180.0) coord = 179.99999; // north pole 90.0 ignored...
+    // adjust for south and west hemispheres
+    if(coord < 0.0 && coord% 1.0 != 0.0) coord -= 1.0;
+    return (int) coord;
+  }
+
   /**
-   * get the srtm data set for a position srtm coords are
-   * srtm_<srtmLon>_<srtmLat> where srtmLon = 180 + lon, srtmLat = 60 - lat
+   * @param srtmLonIdx west bound
+   * @param srtmLatIdx south bound
+   * @return name of the tile in ".hgt" convention, no suffix
    */
+  public String hgtFileName(int srtmLonIdx, int srtmLatIdx){
+    String hemiLon = srtmLonIdx >= 0 ? "E": "W";
+    String hemilat = srtmLatIdx >= 0 ? "N": "S";
+    String lonS = "00" + Math.abs(srtmLonIdx);
+    String latS = "0" + Math.abs(srtmLatIdx);
+    return hemilat + latS.substring(latS.length() - 2) + hemiLon + lonS.substring(lonS.length() -3);
+  }
+
   private SrtmRaster srtmForNode( int ilon, int ilat ) throws Exception
   {
-    int srtmLonIdx = ( ilon + 5000000 ) / 5000000;
-    int srtmLatIdx = ( 654999999 - ilat ) / 5000000 - 100; // ugly negative rounding...
+
+    int srtmLonIdx = lonIndexHgt(ilon);
+    int srtmLatIdx = latIndexHgt(ilat);
 
     if ( srtmLonIdx == lastSrtmLonIdx && srtmLatIdx == lastSrtmLatIdx )
     {
@@ -174,9 +213,11 @@ public class PosUnifier extends MapCreatorBase
     lastSrtmLonIdx = srtmLonIdx;
     lastSrtmLatIdx = srtmLatIdx;
 
-    String slonidx = "0" + srtmLonIdx;
-    String slatidx = "0" + srtmLatIdx;
-    String filename = "srtm_" + slonidx.substring( slonidx.length()-2 ) + "_" + slatidx.substring( slatidx.length()-2 );
+    /*
+    filename represents: .zip archive named by the convention of .hgt files, containing arbitrarily named .asc file
+    and any number of associated files, e.g. N48E012.zip contains N48E012.asc, N48E012.prj, N48E012.asc.aux.xml
+    */
+    String filename = hgtFileName(srtmLonIdx, srtmLatIdx);
 
     lastSrtmRaster = srtmmap.get( filename );
     if ( lastSrtmRaster == null && !srtmmap.containsKey( filename ) )
@@ -221,8 +262,8 @@ public class PosUnifier extends MapCreatorBase
   private void resetSrtm()
   {
     srtmmap = new HashMap<String, SrtmRaster>();
-    lastSrtmLonIdx = -1;
-    lastSrtmLatIdx = -1;
+    lastSrtmLonIdx = -9999;
+    lastSrtmLatIdx = -9999;
     lastSrtmRaster = null;
   }
 

--- a/brouter-map-creator/src/main/java/btools/mapcreator/SrtmData.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/SrtmData.java
@@ -104,14 +104,14 @@ public class SrtmData
         NODATA_value -32768
          414 411 414 420 425 432 430 431 // NOTE THE LEADING WHITESPACE - a file exported from gdal
         */
-        boolean ignoreLeadingWhitespace = true;
+        boolean whitespace = true;
         for ( ;; )
         {
           int c = br.read();
           if ( c < 0 )
             break;
-          if(c == ' ' && ignoreLeadingWhitespace) continue;
-          ignoreLeadingWhitespace = false;
+          if(c == ' ' && whitespace) continue;
+          whitespace = false;
           if ( c == ' ' )
           {
             if ( negative )

--- a/brouter-map-creator/src/main/java/btools/mapcreator/SrtmData.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/SrtmData.java
@@ -95,11 +95,25 @@ public class SrtmData
         int col = 0;
         int n = 0;
         boolean negative = false;
+        /*
+        ncols        1201
+        nrows        1201
+        xllcorner    11.999583333333
+        yllcorner    47.999583333333
+        cellsize     0.000833333333
+        NODATA_value -32768
+         414 411 414 420 425 432 430 431 // NOTE THE LEADING WHITESPACE - a file exported from gdal
+        */
+        boolean ignoreLeadingWhitespace = true;
         for ( ;; )
         {
           int c = br.read();
           if ( c < 0 )
             break;
+          if(c == ' ' && ignoreLeadingWhitespace){
+            ignoreLeadingWhitespace = false;
+            continue;
+          }
           if ( c == ' ' )
           {
             if ( negative )

--- a/brouter-map-creator/src/main/java/btools/mapcreator/SrtmData.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/SrtmData.java
@@ -110,10 +110,8 @@ public class SrtmData
           int c = br.read();
           if ( c < 0 )
             break;
-          if(c == ' ' && ignoreLeadingWhitespace){
-            ignoreLeadingWhitespace = false;
-            continue;
-          }
+          if(c == ' ' && ignoreLeadingWhitespace) continue;
+          ignoreLeadingWhitespace = false;
           if ( c == ' ' )
           {
             if ( negative )

--- a/brouter-map-creator/src/main/java/btools/mapcreator/SrtmRaster.java
+++ b/brouter-map-creator/src/main/java/btools/mapcreator/SrtmRaster.java
@@ -33,8 +33,8 @@ public class SrtmRaster
     }
 
     // no weights calculated, use 2d linear interpolation
-    double dcol = (lon - xllcorner)/cellsize -0.5;
     double drow = (lat - yllcorner)/cellsize -0.5;
+    double dcol = (lon - xllcorner)/cellsize -0.5;
     int row = (int)drow;
     int col = (int)dcol;
     if ( col < 0 ) col = 0;
@@ -45,12 +45,21 @@ public class SrtmRaster
     double wcol = dcol-col;
     missingData = false;
 
-// System.out.println( "wrow=" + wrow + " wcol=" + wcol + " row=" + row + " col=" + col );
+    //System.out.println("drow=" + drow + " dcol: " + dcol);
+    //System.out.println("row=" + row + " col=" + col);
+    //System.out.println( "wrow=" + wrow + " wcol=" + wcol );
+
     double eval = (1.-wrow)*(1.-wcol)*get(row  ,col  )
              + (   wrow)*(1.-wcol)*get(row+1,col  )
              + (1.-wrow)*(   wcol)*get(row  ,col+1)
              + (   wrow)*(   wcol)*get(row+1,col+1);
-// System.out.println( "eval=" + eval );
+
+    //System.out.println(get(row,col));
+    //System.out.println(get(row+1,col));
+    //System.out.println(get(row,col+1));
+    //System.out.println(get(row+1,col+1));
+    //System.out.println( "eval=" + eval );
+
     return missingData ? Short.MIN_VALUE : (short)(eval*4);
   }
 

--- a/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
+++ b/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
@@ -43,7 +43,7 @@ public class PosUnifierTest {
     int[] expected = {-180, -180, -2, -1, -1, 0, 0, 1, 179, 179};
     PosUnifier unifier = new PosUnifier();
     for (int i = 0; i < expected.length; i++) {
-      assert (unifier.indexHgt(coords[i]) == expected[i]);
+      assert (unifier.indexHgt(coords[i], 180.0) == expected[i]);
     }
   }
 

--- a/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
+++ b/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
@@ -67,11 +67,13 @@ public class PosUnifierTest {
   //
 
   private final Coord[] coords = {
-      new Coord(48.0,12.0)
+      new Coord(48.0,12.0),
+      new Coord(48.02,12.0)
   };
 
   @Test
   public void generateIntegrationTestData() throws Exception {
+    double[] elevs = new double[coords.length];
     PosUnifier unifier = new PosUnifier();
     unifier.resetSrtm();
     unifier.setSrtmdir(System.getenv("SRTM_FILES_ROOT_ESRI_ASAMM"));
@@ -81,7 +83,26 @@ public class PosUnifierTest {
       SrtmRaster raster = unifier.srtmForNode(ilon, ilat);
       raster.usingWeights = false;
       double elevation = raster.getElevation(ilon, ilat);
-      System.out.println(coords[i].toString() + elevation / 4); //???
+      elevs[i] = elevation;
+      // System.out.println(coords[i].toString() + elevation / 4); //???
+    }
+    // output
+    for (int i = 0; i < coords.length; i++){
+      System.out.println(coords[i].toString() + (elevs[i] / 4));
+    }
+  }
+
+  @Test
+  public void printFirstRow() throws Exception {
+    PosUnifier unifier = new PosUnifier();
+    unifier.resetSrtm();
+    unifier.setSrtmdir(System.getenv("SRTM_FILES_ROOT_ESRI_ASAMM"));
+    int ilat = (int)( ( 48.0 + 90. )*1000000. + 0.5);
+    int ilon = (int)( ( 12.0 + 180. )*1000000. + 0.5);
+    SrtmRaster raster = unifier.srtmForNode(ilon, ilat);
+    raster.usingWeights = false;
+    for (int i = 0; i < 1203; i ++){
+      System.out.print(raster.eval_array[i] + " ");
     }
   }
 

--- a/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
+++ b/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
@@ -1,0 +1,58 @@
+package btools.mapcreator;
+
+import org.junit.Test;
+
+public class PosUnifierTest {
+
+  @Test
+  public void testHgtFileNameComposition(){
+    int[] lats = {-90,-89,-1,-0,0,1,89,90,   0,0,-1,-1};
+    int[] lons = {-180,-179,-1,-0,0,1,179,180,   0,-1,-1,0};
+    String [] expected = {
+        "S90W180",
+        "S89W179",
+        "S01W001",
+        "N00E000",
+        "N00E000",
+        "N01E001",
+        "N89E179",
+        "N90E180",
+
+
+
+        "N00E000",
+        "N00W001",
+        "S01W001",
+        "S01E000"
+    };
+    PosUnifier unifier = new PosUnifier();
+    for (int i = 0; i < expected.length; i++){
+      String tile = unifier.hgtFileName(lons[i], lats[i]);
+      assert (tile.length() == 7);
+      assert (tile.equals(expected[i]));
+      System.out.println(tile);
+    }
+  }
+
+  @Test
+  public void testIndexingOfDoubleValues(){
+    double[] coords = {-180.0, -179.5, -1.5, -1.0, -0.5, 0.0, 0.1, 1.5, 179.9, 180.0}; // 180.0 exactly: there is no tile 180E
+    int [] expected = {-180, -180, -2, -1, -1, 0, 0, 1, 179, 179};
+    PosUnifier unifier = new PosUnifier();
+    for (int i = 0; i < expected.length; i++) {
+      assert(unifier.indexHgt(coords[i]) == expected[i]);
+    }
+  }
+
+  @Test
+  public void testConversionCoordinates(){
+    double coord = -180.0;
+    PosUnifier unifier = new PosUnifier();
+    while(coord < 180.0){
+      NodeData nd = new NodeData(1, coord, coord);
+      assert(Math.abs(unifier.doublelat(nd.ilat) - coord) < 1E-5);
+      assert(Math.abs(unifier.doublelon(nd.ilon) - coord) < 1E-5);
+      coord += 0.00001;
+    }
+  }
+}

--- a/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
+++ b/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
@@ -78,10 +78,10 @@ public class PosUnifierTest {
     coords.add(new Coord(49.0, 12.0));
     coords.add(new Coord(49.0, 13.0));
 
+    coords.add(new Coord(51.0, 0.0));
+    coords.add(new Coord(51.0, 1.0));
     coords.add(new Coord(52.0, 0.0));
     coords.add(new Coord(52.0, 1.0));
-    coords.add(new Coord(53.0, 0.0));
-    coords.add(new Coord(53.0, 1.0));
 
     coords.add(new Coord(52.5, 0.0));
     coords.add(new Coord(52.5, 0.0001));
@@ -91,12 +91,12 @@ public class PosUnifierTest {
     coords.add(new Coord(-72.5, 0.0001));
     coords.add(new Coord(-72.5, -0.0001));
 
+    coords.add(new Coord(51.0, 0.0));
+    coords.add(new Coord(51.0, -1.0));
     coords.add(new Coord(52.0, 0.0));
     coords.add(new Coord(52.0, -1.0));
-    coords.add(new Coord(53.0, 0.0));
-    coords.add(new Coord(53.0, -1.0));
 
-    coords.add(new Coord(53.2, -1.2));
+    coords.add(new Coord(52.2, -1.2));
 
     coords.add(new Coord(0.0, 23.0));
     coords.add(new Coord(0.0001, 23.0));
@@ -109,12 +109,12 @@ public class PosUnifierTest {
 
     coords.add(new Coord(-14.2, 24.2));
 
-    coords.add(new Coord(-57.0, -13.0));
-    coords.add(new Coord(-57.0, -14.0));
-    coords.add(new Coord(-58.0, -13.0));
-    coords.add(new Coord(-58.0, -14.0));
+    coords.add(new Coord(-33.0, -67.0));
+    coords.add(new Coord(-33.0, -68.0));
+    coords.add(new Coord(-34.0, -67.0));
+    coords.add(new Coord(-34.0, -68.0));
 
-    coords.add(new Coord(-58.2, -14.2));
+    coords.add(new Coord(-34.2, -68.2));
 
     coords.add(new Coord(36.0, -101.0));
     coords.add(new Coord(36.0, -102.0));
@@ -127,7 +127,7 @@ public class PosUnifierTest {
     coords.add(new Coord(66.0, 179.0));
     coords.add(new Coord(66.0, 179.999));
     coords.add(new Coord(66.0, -179.999));
-    coords.add(new Coord(66.0, -180.999));
+    coords.add(new Coord(66.0, -179.999));
 
     coords.add(new Coord(-29.0, 141.0));
     coords.add(new Coord(-29.0, 142.0));
@@ -140,7 +140,7 @@ public class PosUnifierTest {
     Random rnd = new Random();
     int count = 0;
     while (count < n) {
-      coords.add(new Coord(48.0 + rnd.nextDouble(), 12.0 + rnd.nextDouble()));
+      coords.add(new Coord(43.0 + rnd.nextDouble() * 10.0, 19.0 + rnd.nextDouble() * 10.0));
       count++;
     }
   }
@@ -148,7 +148,7 @@ public class PosUnifierTest {
   @Test
   public void generateIntegrationTestData() throws Exception {
     addSelected();
-    addRandom(5);
+    addRandom(100);
     double[] elevs = new double[coords.size()];
     PosUnifier unifier = new PosUnifier();
     unifier.resetSrtm();

--- a/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
+++ b/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
@@ -55,4 +55,47 @@ public class PosUnifierTest {
       coord += 0.00001;
     }
   }
+
+  // integration test - test data generation part
+  // the idea here is to query PosUnifier with coordinates in ilat, ilon format,
+  // then query again returned SrtmRasterObject for coordinates in double format
+  // print values in .csv format so we can assert values with Asamm library for .hgt files
+
+  //
+  // ilat = (int)( ( lat + 90. )*1000000. + 0.5);
+  // ilon = (int)( ( lon + 180. )*1000000. + 0.5);
+  //
+
+  private final Coord[] coords = {
+      new Coord(48.0,12.0)
+  };
+
+  @Test
+  public void generateIntegrationTestData() throws Exception {
+    PosUnifier unifier = new PosUnifier();
+    unifier.resetSrtm();
+    unifier.setSrtmdir(System.getenv("SRTM_FILES_ROOT_ESRI_ASAMM"));
+    for (int i = 0; i < coords.length; i++){
+      int ilat = (int)( ( coords[i].lat + 90. )*1000000. + 0.5);
+      int ilon = (int)( ( coords[i].lon + 180. )*1000000. + 0.5);
+      SrtmRaster raster = unifier.srtmForNode(ilon, ilat);
+      raster.usingWeights = false;
+      double elevation = raster.getElevation(ilon, ilat);
+      System.out.println(coords[i].toString() + elevation / 4); //???
+    }
+  }
+
+  class Coord{
+    protected Coord(double lat, double lon){
+      this.lat = lat;
+      this.lon = lon;
+    }
+    double lat;
+    double lon;
+
+    @Override
+    public String toString(){
+      return this.lat + "," + this.lon + ",";
+    }
+  }
 }

--- a/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
+++ b/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
@@ -72,10 +72,58 @@ public class PosUnifierTest {
   private final List<Coord> coords = new ArrayList<Coord>();
 
   private void addSelected() {
+
     coords.add(new Coord(48.0, 12.0));
     coords.add(new Coord(48.0, 13.0));
     coords.add(new Coord(49.0, 12.0));
     coords.add(new Coord(49.0, 13.0));
+
+    coords.add(new Coord(52.0, 0.0));
+    coords.add(new Coord(52.0, 1.0));
+    coords.add(new Coord(53.0, 0.0));
+    coords.add(new Coord(53.0, 1.0));
+
+    coords.add(new Coord(52.5, 0.0));
+    coords.add(new Coord(52.5, 0.0001));
+    coords.add(new Coord(52.5, -0.0001));
+
+    coords.add(new Coord(52.0, 0.0));
+    coords.add(new Coord(52.0, -1.0));
+    coords.add(new Coord(53.0, 0.0));
+    coords.add(new Coord(53.0, -1.0));
+
+    coords.add(new Coord(52.0, 0.0));
+    coords.add(new Coord(52.0, -1.0));
+    coords.add(new Coord(53.0, 0.0));
+    coords.add(new Coord(53.0, -1.0));
+
+    coords.add(new Coord(53.2, -1.2));
+
+    coords.add(new Coord(0.0, 23.0));
+    coords.add(new Coord(0.0001, 23.0));
+    coords.add(new Coord(-0.0001, 23.0));
+
+    coords.add(new Coord(-13.0, 23.0));
+    coords.add(new Coord(-13.0, 24.0));
+    coords.add(new Coord(-14.0, 23.0));
+    coords.add(new Coord(-14.0, 24.0));
+
+    coords.add(new Coord(-14.2, 24.2));
+
+    coords.add(new Coord(-57.0, -13.0));
+    coords.add(new Coord(-57.0, -14.0));
+    coords.add(new Coord(-58.0, -13.0));
+    coords.add(new Coord(-58.0, -14.0));
+
+    coords.add(new Coord(-58.2, -14.2));
+
+    coords.add(new Coord(36.0, -101.0));
+    coords.add(new Coord(36.0, -102.0));
+    coords.add(new Coord(37.0, -101.0));
+    coords.add(new Coord(37.0, -102.0));
+
+    coords.add(new Coord(37.2, -102.2));
+
   }
 
   private void addRandom(int n) {
@@ -90,7 +138,7 @@ public class PosUnifierTest {
   @Test
   public void generateIntegrationTestData() throws Exception {
     addSelected();
-    addRandom(20);
+    addRandom(5);
     double[] elevs = new double[coords.size()];
     PosUnifier unifier = new PosUnifier();
     unifier.resetSrtm();

--- a/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
+++ b/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
@@ -2,13 +2,17 @@ package btools.mapcreator;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
 public class PosUnifierTest {
 
   @Test
-  public void testHgtFileNameComposition(){
-    int[] lats = {-90,-89,-1,-0,0,1,89,90,   0,0,-1,-1};
-    int[] lons = {-180,-179,-1,-0,0,1,179,180,   0,-1,-1,0};
-    String [] expected = {
+  public void testHgtFileNameComposition() {
+    int[] lats = {-90, -89, -1, -0, 0, 1, 89, 90, 0, 0, -1, -1};
+    int[] lons = {-180, -179, -1, -0, 0, 1, 179, 180, 0, -1, -1, 0};
+    String[] expected = {
         "S90W180",
         "S89W179",
         "S01W001",
@@ -19,14 +23,13 @@ public class PosUnifierTest {
         "N90E180",
 
 
-
         "N00E000",
         "N00W001",
         "S01W001",
         "S01E000"
     };
     PosUnifier unifier = new PosUnifier();
-    for (int i = 0; i < expected.length; i++){
+    for (int i = 0; i < expected.length; i++) {
       String tile = unifier.hgtFileName(lons[i], lats[i]);
       assert (tile.length() == 7);
       assert (tile.equals(expected[i]));
@@ -35,23 +38,23 @@ public class PosUnifierTest {
   }
 
   @Test
-  public void testIndexingOfDoubleValues(){
+  public void testIndexingOfDoubleValues() {
     double[] coords = {-180.0, -179.5, -1.5, -1.0, -0.5, 0.0, 0.1, 1.5, 179.9, 180.0}; // 180.0 exactly: there is no tile 180E
-    int [] expected = {-180, -180, -2, -1, -1, 0, 0, 1, 179, 179};
+    int[] expected = {-180, -180, -2, -1, -1, 0, 0, 1, 179, 179};
     PosUnifier unifier = new PosUnifier();
     for (int i = 0; i < expected.length; i++) {
-      assert(unifier.indexHgt(coords[i]) == expected[i]);
+      assert (unifier.indexHgt(coords[i]) == expected[i]);
     }
   }
 
   @Test
-  public void testConversionCoordinates(){
+  public void testConversionCoordinates() {
     double coord = -180.0;
     PosUnifier unifier = new PosUnifier();
-    while(coord < 180.0){
+    while (coord < 180.0) {
       NodeData nd = new NodeData(1, coord, coord);
-      assert(Math.abs(unifier.doublelat(nd.ilat) - coord) < 1E-5);
-      assert(Math.abs(unifier.doublelon(nd.ilon) - coord) < 1E-5);
+      assert (Math.abs(unifier.doublelat(nd.ilat) - coord) < 1E-5);
+      assert (Math.abs(unifier.doublelon(nd.ilon) - coord) < 1E-5);
       coord += 0.00001;
     }
   }
@@ -66,29 +69,43 @@ public class PosUnifierTest {
   // ilon = (int)( ( lon + 180. )*1000000. + 0.5);
   //
 
-  private final Coord[] coords = {
-      new Coord(48.0,12.0),
-      new Coord(48.02,12.0)
-  };
+  private final List<Coord> coords = new ArrayList<Coord>();
+
+  private void addSelected() {
+    coords.add(new Coord(48.0, 12.0));
+    coords.add(new Coord(48.0, 13.0));
+    coords.add(new Coord(49.0, 12.0));
+    coords.add(new Coord(49.0, 13.0));
+  }
+
+  private void addRandom(int n) {
+    Random rnd = new Random();
+    int count = 0;
+    while (count < n) {
+      coords.add(new Coord(48.0 + rnd.nextDouble(), 12.0 + rnd.nextDouble()));
+      count++;
+    }
+  }
 
   @Test
   public void generateIntegrationTestData() throws Exception {
-    double[] elevs = new double[coords.length];
+    addSelected();
+    addRandom(20);
+    double[] elevs = new double[coords.size()];
     PosUnifier unifier = new PosUnifier();
     unifier.resetSrtm();
     unifier.setSrtmdir(System.getenv("SRTM_FILES_ROOT_ESRI_ASAMM"));
-    for (int i = 0; i < coords.length; i++){
-      int ilat = (int)( ( coords[i].lat + 90. )*1000000. + 0.5);
-      int ilon = (int)( ( coords[i].lon + 180. )*1000000. + 0.5);
+    for (int i = 0; i < coords.size(); i++) {
+      int ilat = (int) ((coords.get(i).lat + 90.) * 1000000. + 0.5);
+      int ilon = (int) ((coords.get(i).lon + 180.) * 1000000. + 0.5);
       SrtmRaster raster = unifier.srtmForNode(ilon, ilat);
       raster.usingWeights = false;
       double elevation = raster.getElevation(ilon, ilat);
       elevs[i] = elevation;
-      // System.out.println(coords[i].toString() + elevation / 4); //???
     }
     // output
-    for (int i = 0; i < coords.length; i++){
-      System.out.println(coords[i].toString() + (elevs[i] / 4));
+    for (int i = 0; i < coords.size(); i++) {
+      System.out.println(coords.get(i).toString() + (elevs[i] / 4)); // ???
     }
   }
 
@@ -97,25 +114,26 @@ public class PosUnifierTest {
     PosUnifier unifier = new PosUnifier();
     unifier.resetSrtm();
     unifier.setSrtmdir(System.getenv("SRTM_FILES_ROOT_ESRI_ASAMM"));
-    int ilat = (int)( ( 48.0 + 90. )*1000000. + 0.5);
-    int ilon = (int)( ( 12.0 + 180. )*1000000. + 0.5);
+    int ilat = (int) ((48.0 + 90.) * 1000000. + 0.5);
+    int ilon = (int) ((12.0 + 180.) * 1000000. + 0.5);
     SrtmRaster raster = unifier.srtmForNode(ilon, ilat);
     raster.usingWeights = false;
-    for (int i = 0; i < 1203; i ++){
+    for (int i = 0; i < 1203; i++) {
       System.out.print(raster.eval_array[i] + " ");
     }
   }
 
-  class Coord{
-    protected Coord(double lat, double lon){
+  class Coord {
+    protected Coord(double lat, double lon) {
       this.lat = lat;
       this.lon = lon;
     }
+
     double lat;
     double lon;
 
     @Override
-    public String toString(){
+    public String toString() {
       return this.lat + "," + this.lon + ",";
     }
   }

--- a/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
+++ b/brouter-map-creator/src/test/java/btools/mapcreator/PosUnifierTest.java
@@ -87,10 +87,9 @@ public class PosUnifierTest {
     coords.add(new Coord(52.5, 0.0001));
     coords.add(new Coord(52.5, -0.0001));
 
-    coords.add(new Coord(52.0, 0.0));
-    coords.add(new Coord(52.0, -1.0));
-    coords.add(new Coord(53.0, 0.0));
-    coords.add(new Coord(53.0, -1.0));
+    coords.add(new Coord(-72.5, 0.0));
+    coords.add(new Coord(-72.5, 0.0001));
+    coords.add(new Coord(-72.5, -0.0001));
 
     coords.add(new Coord(52.0, 0.0));
     coords.add(new Coord(52.0, -1.0));
@@ -123,6 +122,17 @@ public class PosUnifierTest {
     coords.add(new Coord(37.0, -102.0));
 
     coords.add(new Coord(37.2, -102.2));
+
+    coords.add(new Coord(66.0, 180.0));
+    coords.add(new Coord(66.0, 179.0));
+    coords.add(new Coord(66.0, 179.999));
+    coords.add(new Coord(66.0, -179.999));
+    coords.add(new Coord(66.0, -180.999));
+
+    coords.add(new Coord(-29.0, 141.0));
+    coords.add(new Coord(-29.0, 142.0));
+    coords.add(new Coord(-30.0, 141.0));
+    coords.add(new Coord(-30.0, 142.0));
 
   }
 


### PR DESCRIPTION
The purpose of this PR is mainly to introduce related work and double check logic that determines tiles used. -hgt files naming convention is used for Esri grid tiles too. Also an integration test is introduced. Both selected and randomly chosen locations over the planet are measured and compared to results from Asamm dataset using ElevationAPI. This comparison is not part of this PR, there is a separate project including an Retrofit client from LoPoints library. 
Differences in elevation: if there is more than 2.0 m difference, the test fails. Failed test results IMO illustrate how 2d linear interpolation (brouter) and bicubic interpolation (Asamm) work.
Test cases: ~60 manually selected locations, 100 random locations (Europe)
Asserts failed
 brouter: 648.5 | Asamm: 650.8514146782333 diff: 2.3514146782332546
 brouter: 884.0 | Asamm: 886.1465701986641 diff: 2.146570198664108
 brouter: 1330.75 | Asamm: 1334.5088137411317 diff: 3.7588137411316893

Replacing interpolation algorithm should not be too difficult.
 